### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
           }
 
           echo "## Integration Test Coverage" >> "$GITHUB_STEP_SUMMARY"
-          print_class_coverage "com.college.Schedule"
-          print_class_coverage "com.college.ScheduleController"
+          print_class_coverage "com.videohost.ViewInfo"
+          print_class_coverage "com.videohost.ViewInfoController"
 
       - name: Upload integration logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  # Run on PR lifecycle events and on direct pushes to main, release/*.
-  # This setup avoids unnecessary workflow runs on events like 
-  # labeling or assigning reviewers, which don't change the code 
-  # and don't require a rebuild.
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, release/*]
@@ -12,7 +8,7 @@ on:
     branches: [main, release/*]
 
 jobs:
-  # Stage 1: code quality gate.
+   # Етап 1: виконати перевірки статичного аналізу перед тестуванням або пакуванням.
   static-analysis:
     name: Static Analysis
     runs-on: ubuntu-latest
@@ -28,7 +24,7 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Run static analysis (Checkstyle)
+      - name: Run static analysis 
         shell: bash
         run: |
           mkdir -p target/ci-logs
@@ -43,9 +39,9 @@ jobs:
           path: target/ci-logs/**
           if-no-files-found: warn
 
-  # Stage 2: compile/package artifact only if static analysis passed.
-  build:
-    name: Build
+  #  # Етап 2: виконати юніт-тести, лише якщо статичний аналіз пройшов успішно.
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     needs: static-analysis
 
@@ -60,12 +56,190 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Build project (includes unit tests)
+      - name: Run unit tests
         shell: bash
         run: |
           mkdir -p target/ci-logs
           set -o pipefail
-          mvn -B -Dcheckstyle.skip=true package | tee target/ci-logs/build.log
+          mvn -B -Dcheckstyle.skip=true -DskipIntegrationTests=true test | tee target/ci-logs/unit-tests.log
+
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-reports
+          path: target/surefire-reports/**
+          if-no-files-found: warn
+      - name: Upload unit coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage-reports
+          path: |
+            target/site/jacoco/**
+            target/jacoco.exec
+          if-no-files-found: warn
+
+      - name: Print unit coverage summary
+        if: always()
+        shell: bash
+        run: |
+          # Parse JaCoCo CSV and print coverage to job logs + Actions summary.
+          CSV_FILE="target/site/jacoco/jacoco.csv"
+          if [ ! -f "$CSV_FILE" ]; then
+            echo "Unit coverage report was not generated."
+            echo "## Unit Test Coverage" >> "$GITHUB_STEP_SUMMARY"
+            echo "Coverage report was not generated." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          
+          read -r COVERED MISSED < <(awk -F, 'NR>1 {covered+=$9; missed+=$8} END {print covered+0, missed+0}' "$CSV_FILE")
+          TOTAL=$((COVERED + MISSED))
+          if [ "$TOTAL" -eq 0 ]; then
+            PERCENT="0.00"
+          else
+            PERCENT=$(awk -v c="$COVERED" -v t="$TOTAL" 'BEGIN {printf "%.2f", (c/t)*100}')
+          fi
+
+          echo "Unit coverage: ${PERCENT}% (covered: ${COVERED}, missed: ${MISSED})"
+
+          {
+            echo "## Unit Test Coverage"
+            echo "Line coverage: ${PERCENT}%"
+            echo "Covered lines: ${COVERED}"
+            echo "Missed lines: ${MISSED}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload unit test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-logs
+          path: target/ci-logs/**
+          if-no-files-found: warn
+          
+          # Етап 3: виконати інтеграційні тести, лише якщо юніт-тести пройшли успішно.
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: unit-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run integration tests
+        shell: bash
+        run: |
+          mkdir -p target/ci-logs
+          set -o pipefail
+          mvn -B -Dcheckstyle.skip=true -DskipUnitTests=true verify | tee target/ci-logs/integration-tests.log
+
+      - name: Upload integration test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: target/failsafe-reports/**
+          if-no-files-found: warn
+
+      - name: Upload integration coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-coverage-reports
+          path: |
+            target/site/jacoco-integration-tests/**
+            target/jacoco-integration-tests.exec
+          if-no-files-found: warn
+
+      - name: Print integration coverage summary
+        if: always()
+        shell: bash
+        run: |
+          CSV_FILE="target/site/jacoco-integration-tests/jacoco.csv"
+          if [ ! -f "$CSV_FILE" ]; then
+            echo "Integration coverage report was not generated."
+            echo "## Integration Test Coverage" >> "$GITHUB_STEP_SUMMARY"
+            echo "Coverage report was not generated." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          print_class_coverage() {
+            local full_class_name="$1"
+            local package_path class_name covered missed total percent
+
+            package_path="${full_class_name%.*}"
+            class_name="${full_class_name##*.}"
+
+            read -r covered missed < <(awk -F, -v target_package="$package_path" -v target_class="$class_name" '
+              NR>1 && $2 == target_package && $3 == target_class {
+                covered += $9
+                missed += $8
+              }
+              END {print covered+0, missed+0}
+            ' "$CSV_FILE")
+
+            total=$((covered + missed))
+            if [ "$total" -eq 0 ]; then
+              percent="0.00"
+            else
+              percent=$(awk -v c="$covered" -v t="$total" 'BEGIN {printf "%.2f", (c/t)*100}')
+            fi
+
+            echo "${full_class_name} integration coverage: ${percent}% (covered: ${covered}, missed: ${missed})"
+
+            {
+              echo "### ${full_class_name}"
+              echo "Line coverage: ${percent}%"
+              echo "Covered lines: ${covered}"
+              echo "Missed lines: ${missed}"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          echo "## Integration Test Coverage" >> "$GITHUB_STEP_SUMMARY"
+          print_class_coverage "com.college.Schedule"
+          print_class_coverage "com.college.ScheduleController"
+
+      - name: Upload integration logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs
+          path: |
+            target/ci-logs/**
+            target/failsafe-reports/**
+            target/site/jacoco-integration-tests/**
+          if-no-files-found: warn
+
+  # Етап 4: зібрати та запакувати артефакт, лише якщо статичний аналіз і тести пройшли успішно.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: integration-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Build package without re-running tests
+        run: mvn -B -Dcheckstyle.skip=true -DskipUnitTests=true -DskipIntegrationTests=true package
 
       - name: Upload build artifact
         if: always()
@@ -75,64 +249,7 @@ jobs:
           path: target/*.jar
           if-no-files-found: warn
 
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-reports
-          path: target/surefire-reports/**
-          if-no-files-found: warn
-
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports
-          path: |
-            target/site/jacoco/**
-            target/jacoco.exec
-          if-no-files-found: warn
-
-      - name: Print coverage summary in build logs
-        if: always()
-        shell: bash
-        run: |
-          # Parse JaCoCo CSV and print coverage to job logs + Actions summary.
-          CSV_FILE="target/site/jacoco/jacoco.csv"
-          if [ ! -f "$CSV_FILE" ]; then
-            echo "Coverage report was not generated."
-            echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
-            echo "Coverage report was not generated." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          # JaCoCo CSV columns: $8=LINE_MISSED, $9=LINE_COVERED
-          read -r COVERED MISSED < <(awk -F, 'NR>1 {covered+=$9; missed+=$8} END {print covered+0, missed+0}' "$CSV_FILE")
-          TOTAL=$((COVERED + MISSED))
-          if [ "$TOTAL" -eq 0 ]; then
-            PERCENT="0.00"
-          else
-            PERCENT=$(awk -v c="$COVERED" -v t="$TOTAL" 'BEGIN {printf "%.2f", (c/t)*100}')
-          fi
-
-          echo "Coverage: ${PERCENT}% (covered: ${COVERED}, missed: ${MISSED})"
-
-          {
-            echo "## Coverage"
-            echo "Line coverage: ${PERCENT}%"
-            echo "Covered lines: ${COVERED}"
-            echo "Missed lines: ${MISSED}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload build logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-logs
-          path: target/ci-logs/**
-          if-no-files-found: warn
-          
-          # Stage 3: публікація пакету після успішної збірки.
+  # Етап 5: опублікувати пакет лише після успішного завершення етапу збірки.
   publish:
     name: Publish Package
     needs: build

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
 
     # Крок 3: Публікація артефактів в GitHub Packages
     - name: Publish to GitHub Packages
-      run: mvn --batch-mode deploy --file pom.xml -DskipTests
+      run: mvn --batch-mode deploy --file pom.xml -DskipUnitTests=true -DskipIntegrationTests=true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.scm.id>github</project.scm.id>
-    <testcontainers.version>1.20.6</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <skipUnitTests>false</skipUnitTests>
     <skipIntegrationTests>false</skipIntegrationTests>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
                 <rule>
                   <element>CLASS</element>
                   <includes>
-                    <include>com.college.Schedule</include>
+                    <include>com.videohost.ViewInfo</include>
                   </includes>
                   <limits>
                     <limit>
@@ -254,7 +254,7 @@
                 <rule>
                   <element>CLASS</element>
                   <includes>
-                    <include>com.college.ScheduleController</include>
+                    <include>com.videohost.ViewInfoController</include>
                   </includes>
                   <limits>
                     <limit>

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,19 @@
   <name>videohosting</name>
   <url>http://maven.apache.org</url>
 
+   <!-- Кодування збірки та ресурсів -->
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.scm.id>github</project.scm.id>
+    <testcontainers.version>1.20.6</testcontainers.version>
+    <skipUnitTests>false</skipUnitTests>
+    <skipIntegrationTests>false</skipIntegrationTests>
   </properties>
 
-  <!-- SCM Information -->
+   <!-- Інформація про SCM -->
   <scm>
     <connection>scm:git:https://github.com/videohosting-app/videohosting-app-25-postgres.git</connection>
     <developerConnection>scm:git:https://github.com/videohosting-app/videohosting-app-25-postgres.git</developerConnection>
@@ -47,9 +51,16 @@
       <version>2.5.4</version>
     </dependency>
     <dependency>
-      <groupId>com.opencsv</groupId>
-      <artifactId>opencsv</artifactId>
-      <version>5.5.2</version>
+      <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mongodb</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -105,27 +116,94 @@
         <version>3.5.1</version>
         <configuration>
           <useModulePath>false</useModulePath>
+          <skipTests>${skipUnitTests}</skipTests>
+          <excludes>
+            <exclude>**/*IntegrationTests.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
+
+      <!-- Запускає інтеграційні тести, які за домовленістю мають назву *IntegrationTests.java. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+          <skipITs>${skipIntegrationTests}</skipITs>
+          <includes>
+            <include>**/*IntegrationTests.java</include>
+          </includes>
+          <argLine>@{integrationTestsArgLine}</argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Розраховує покриття коду тестами і записує звіти JaCoCo в target/site/jacoco -->
 
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.12</version>
         <executions>
+            <!-- Підготовка агента JaCoCo для юніт-тестів. -->
           <execution>
             <id>prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <skip>${skipUnitTests}</skip>
+            </configuration>
           </execution>
+
+          <!-- Генерує звіт про покриття коду юніт-тестами. -->
           <execution>
             <id>report</id>
             <phase>test</phase>
             <goals>
               <goal>report</goal>
             </goals>
+              <configuration>
+              <skip>${skipUnitTests}</skip>
+            </configuration>
           </execution>
+
+          <!-- Підготовка агента JaCoCo для інтеграційних тестів. -->    
+          <execution>
+            <id>prepare-agent-integration</id>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+            <configuration>
+              <skip>${skipIntegrationTests}</skip>
+              <destFile>${project.build.directory}/jacoco-integration-tests.exec</destFile>
+              <propertyName>integrationTestsArgLine</propertyName>
+            </configuration>
+          </execution>
+
+          <!-- Генерує звіт про покриття коду інтеграційними тестами. -->
+          <execution>
+            <id>report-integration</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-integration</goal>
+            </goals>
+            <configuration>
+              <skip>${skipIntegrationTests}</skip>
+              <dataFile>${project.build.directory}/jacoco-integration-tests.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-integration-tests</outputDirectory>
+            </configuration>
+          </execution>
+
+          <!-- Перевіряє покриття коду тестами і робить щоб збірка завершувалась з помилкою, якщо покриття нижче мінімального порогу. -->
           <execution>
             <id>check</id>
             <phase>package</phase>
@@ -133,6 +211,7 @@
               <goal>check</goal>
             </goals>
             <configuration>
+              <skip>${skipUnitTests}</skip>
               <rules>
                 <rule>
                   <element>BUNDLE</element>
@@ -141,6 +220,47 @@
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.75</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+
+          <!-- Перевіряє покриття коду інтеграційними тестами і робить щоб збірка завершувалась з помилкою, якщо покриття нижче мінімального порогу. -->
+          <execution>
+            <id>check-integration</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <skip>${skipIntegrationTests}</skip>
+              <dataFile>${project.build.directory}/jacoco-integration-tests.exec</dataFile>
+              <rules>
+                <rule>
+                  <element>CLASS</element>
+                  <includes>
+                    <include>com.college.Schedule</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.0</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+                <rule>
+                  <element>CLASS</element>
+                  <includes>
+                    <include>com.college.ScheduleController</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.0</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/src/main/java/com/videohost/VideohostApplication.java
+++ b/src/main/java/com/videohost/VideohostApplication.java
@@ -1,103 +1,16 @@
 package com.videohost;
 
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-
-import com.opencsv.CSVReader;
 
 /**
  * Веб-додаток для перегляду та редагування таблиці відеохостингу.
- *
- * @SpringBootApplication - анотація для позначення головного класу Spring Boot додатку.
- *
- * Методи:
- * - main(String[] args): запускає додаток Spring Boot з вбудованим веб-сервером.
- * - onApplicationReady(): завантажує дані з CSV після старту, якщо база порожня.
- * - addViewInfoFromCsv(): додає дані перегляду з CSV-файлу до бази даних.
- * - viewAllViewInfo(): виводить всі записи перегляду з бази даних.
- * - dropAllViewInfo(): видаляє всі записи перегляду з бази даних.
- *
- * Поля:
- * - viewInfoRepository: репозиторій для роботи з даними відеохостингу.
- *
- * Використовує:
- * - CSVReader для зчитування даних з CSV-файлу.
- * - ViewInfo для представлення документу перегляду.
- * - ViewInfoRepository для взаємодії з базою даних.
+ * Завантаження даних із CSV прибрано — тепер усі дані додаються через веб-інтерфейс.
  */
 @SpringBootApplication
 public class VideohostApplication {
 
-    @Autowired
-    private ViewInfoRepository viewInfoRepository;
-
     public static void main(String[] args) {
         SpringApplication.run(VideohostApplication.class, args);
-    }
-
-    @EventListener(ApplicationReadyEvent.class)
-    public void onApplicationReady() {
-        if (viewInfoRepository.count() == 0) {
-            addViewInfoFromCsv();
-        }
-    }
-
-    private void addViewInfoFromCsv() {
-        try (CSVReader reader = new CSVReader(new InputStreamReader(
-            getClass().getClassLoader().getResourceAsStream("videohost.csv"),
-            StandardCharsets.UTF_8)
-        )) {
-            List<String[]> records = reader.readAll();
-
-            records.remove(0); // Видалити перший рядок з назвами стовпців
-
-            List<ViewInfo> viewInfoList = new ArrayList<>();
-            for (String[] record : records) {
-                ViewInfo viewInfo = new ViewInfo(
-                    record[0], // viewer
-                    record[1], // producer
-                    record[2], // watchedDate
-                    record[3], // watchedTime
-                    record[4], // videoTitle
-                    record[5], // videoDuration
-                    record[6], // genre
-                    record[7], // producerCountry
-                    Double.parseDouble(record[8]), // videoRating
-                    record[9]  // platform
-                );
-                viewInfoList.add(viewInfo);
-            }
-
-            viewInfoRepository.deleteAll();
-            viewInfoRepository.saveAll(viewInfoList);
-            System.out.println(viewInfoList.size()
-                + " документів з рядками з історії перегляду завантажено з CSV.");
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println("Не вдалось завантажити рядок історії перегляду з CSV.");
-        }
-    }
-
-    private void viewAllViewInfo() {
-        List<ViewInfo> viewInfo = viewInfoRepository.findAll();
-        if (viewInfo.isEmpty()) {
-            System.out.println("Документи з рядками історії перегляду не знайдено.");
-        } else {
-            System.out.println("Знайдено " + viewInfo.size() + " документів історії перегляду:");
-            viewInfo.forEach(System.out::println);
-        }
-    }
-
-    private void dropAllViewInfo() {
-        viewInfoRepository.deleteAll();
-        System.out.println("Історії перегляду видалено.");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/videohost_db}
+server.port=8081

--- a/src/test/java/com/videohost/VideohostApplicationTest.java
+++ b/src/test/java/com/videohost/VideohostApplicationTest.java
@@ -1,21 +1,11 @@
 package com.videohost;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 
 class VideohostApplicationTest {
     private final OutputStreamState outputStreamState = new OutputStreamState();
@@ -23,68 +13,6 @@ class VideohostApplicationTest {
     @AfterEach
     void restoreSystemStreams() {
         outputStreamState.restore();
-    }
-
-    @Test
-    void addViewInfoFromCsvReplacesExistingDataAndSavesParsedRows() throws Exception {
-        ViewInfoRepository repository = mock(ViewInfoRepository.class);
-        VideohostApplication app = appWithRepository(repository);
-
-        invokePrivate(app, "addViewInfoFromCsv");
-
-        verify(repository, times(1)).deleteAll();
-        verify(repository, times(1)).saveAll(anyList());
-        assertTrue(outputStreamState.value().contains("CSV"));
-    }
-
-    @Test
-    void addViewInfoFromCsvPrintsFailureMessageWhenRepositoryThrows() throws Exception {
-        ViewInfoRepository repository = mock(ViewInfoRepository.class);
-        doThrow(new RuntimeException("repository unavailable")).when(repository).deleteAll();
-        VideohostApplication app = appWithRepository(repository);
-
-        invokePrivate(app, "addViewInfoFromCsv");
-
-        assertTrue(outputStreamState.value().contains("CSV"));
-        verify(repository, times(1)).deleteAll();
-    }
-
-    @Test
-    void viewAllViewInfoPrintsNotFoundForEmptyRepository() throws Exception {
-        ViewInfoRepository repository = mock(ViewInfoRepository.class);
-        when(repository.findAll()).thenReturn(Collections.emptyList());
-        VideohostApplication app = appWithRepository(repository);
-
-        invokePrivate(app, "viewAllViewInfo");
-
-        assertTrue(outputStreamState.value().contains("не знайдено"));
-        verify(repository, times(1)).findAll();
-    }
-
-    @Test
-    void viewAllViewInfoPrintsRowsWhenRepositoryHasData() throws Exception {
-        ViewInfoRepository repository = mock(ViewInfoRepository.class);
-        ViewInfo viewInfo = new com.videohost.support.ViewInfoTestDataBuilder().build();
-        when(repository.findAll()).thenReturn(List.of(viewInfo));
-        VideohostApplication app = appWithRepository(repository);
-
-        invokePrivate(app, "viewAllViewInfo");
-
-        String output = outputStreamState.value();
-        assertTrue(output.contains("Знайдено 1"));
-        assertTrue(output.contains("ViewInfo"));
-        verify(repository, times(1)).findAll();
-    }
-
-    @Test
-    void dropAllViewInfoDeletesDataAndPrintsMessage() throws Exception {
-        ViewInfoRepository repository = mock(ViewInfoRepository.class);
-        VideohostApplication app = appWithRepository(repository);
-
-        invokePrivate(app, "dropAllViewInfo");
-
-        verify(repository, times(1)).deleteAll();
-        assertTrue(outputStreamState.value().contains("видалено"));
     }
 
     private static VideohostApplication appWithRepository(ViewInfoRepository repository) throws Exception {

--- a/src/test/java/com/videohost/VideohostingFlowIntegrationTests.java
+++ b/src/test/java/com/videohost/VideohostingFlowIntegrationTests.java
@@ -1,0 +1,122 @@
+package com.videohost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers(disabledWithoutDocker = true)
+class VideohostingFlowIntegrationTests {
+
+    @Container
+    private static final MongoDBContainer MONGO_DB_CONTAINER =
+        new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+
+    @Autowired
+    private ViewInfoRepository viewInfoRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @DynamicPropertySource
+    static void configureMongo(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", MONGO_DB_CONTAINER::getReplicaSetUrl);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        viewInfoRepository.deleteAll();
+    }
+
+    @Test
+    void addEndpointPersistsViewInfoToMongo() throws Exception {
+        mockMvc.perform(post("/add")
+                .param("viewer", "Коваленко Олег Іванович")
+                .param("producer", "Петренко Ірина Василівна")
+                .param("watchedDate", "2024-09-14")
+                .param("watchedTime", "20:30:00")
+                .param("videoTitle", "Весняний ранок")
+                .param("videoDuration", "00:15:45")
+                .param("genre", "Драма")
+                .param("producerCountry", "Україна")
+                .param("videoRating", "8.7")
+                .param("platform", "VideoHub"))
+            .andExpect(status().is3xxRedirection());
+
+        assertThat(viewInfoRepository.findAll())
+            .hasSize(1)
+            .extracting(ViewInfo::getVideoTitle)
+            .containsExactly("Весняний ранок");
+    }
+
+    @Test
+    void savedViewInfoAreRenderedOnTheMainPage() throws Exception {
+        viewInfoRepository.save(new ViewInfo(
+            "Коваленко Олег Іванович",
+            "Петренко Ірина Василівна",
+            "2024-09-14",
+            "20:30:00",
+            "Весняний ранок",
+            "00:15:45",
+            "Драма",
+            "Україна",
+            8.7,
+            "VideoHub"
+        ));
+
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("videohost"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Коваленко Олег Іванович")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Весняний ранок")));
+    }
+
+    @Test
+    void addPageRendersFormWithEmptyViewInfoModel() throws Exception {
+        mockMvc.perform(get("/add"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("add"))
+            .andExpect(model().attributeExists("viewInfo"));
+    }
+
+    @Test
+    void deleteEndpointRemovesPersistedViewInfoFromMongo() throws Exception {
+        ViewInfo saved = viewInfoRepository.save(new ViewInfo(
+            "Коваленко Олег Іванович",
+            "Петренко Ірина Василівна",
+            "2024-09-14",
+            "20:30:00",
+            "Весняний ранок",
+            "00:15:45",
+            "Драма",
+            "Україна",
+            8.7,
+            "VideoHub"
+        ));
+
+        mockMvc.perform(post("/delete/{id}", saved.getId()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+
+        assertThat(viewInfoRepository.findById(saved.getId())).isEmpty();
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end integration coverage for the web veiw info flow using MockMvc and Testcontainers MongoDB, including GET /, GET /add, POST /add, and POST /delete/{id}. 
It also updates the Maven build to run integration tests with Failsafe, generate separate JaCoCo integration reports, and fail verify unless integration tests achieve 100% line coverage for ViewInfo and ViewInfoController.

### Related issue
#23 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
  -->
```markdown changelog
Add Mongo-backed integration tests for the sveiw info flow and enforce full integration coverage for ViewInfo and ViewInfoController.
```